### PR TITLE
Added support for "qx.ui.form.Spinner" for form and Russina loalization

### DIFF
--- a/config.json
+++ b/config.json
@@ -34,7 +34,7 @@
     "QOOXDOO_PATH" : "../../../qooxdoo",
     "QXTHEME"      : "dialog.demo.theme.Theme",
     "API_EXCLUDE"  : ["qx.test.*"],
-    "LOCALES"      : [ "en","de","fr" ],
+    "LOCALES"      : [ "en","de","fr", "ru" ],
     "ROOT"         : "."
   },
 

--- a/source/class/dialog/Form.js
+++ b/source/class/dialog/Form.js
@@ -243,6 +243,29 @@ qx.Class.define("dialog.Form", {
           case "checkbox":
             formElement = new qx.ui.form.CheckBox(fieldData.label);
             break;
+          case "spinner":
+            formElement = new qx.ui.form.Spinner();
+            if (fieldData.min) {
+              formElement.setMinimum(fieldData.min);
+            }
+            if (fieldData.max) {
+              formElement.setMaximum(fieldData.max);
+            }
+            if (fieldData.step) {
+              formElement.setSingleStep(fieldData.step);
+            }
+            if(fieldData.fractionsDigits) {
+              var fd = fieldData.fractionsDigits;
+              var nf = new qx.util.format.NumberFormat();
+              if(fd.min) {
+                nf.setMinimumFractionDigits(fd.min);
+              }
+              if(fd.max) {
+                nf.setMaximumFractionDigits(fd.max);
+              }
+              formElement.setNumberFormat(nf);
+            }
+            break;
           default:
             this.error("Invalid form field type:" + fieldData.type);
         }
@@ -255,6 +278,7 @@ qx.Class.define("dialog.Form", {
             case "passwordfield":
             case "combobox":
             case "datefield":
+            case "spinner":
               this._formController.addTarget(formElement, "value", key, true, null, {
                 converter: function (value) {
                   _this._form.getValidationManager().validate();

--- a/source/class/dialog/demo/Application.js
+++ b/source/class/dialog/demo/Application.js
@@ -330,7 +330,16 @@ qx.Class.define("dialog.demo.Application",
           "dateFormat" : new qx.util.format.DateFormat("dd.MM.yyyy HH:mm"),
           "value" : new Date(),
           "label" : "Execute At"
-       }
+        },
+        "area": {
+          "type": "spinner",
+          "label": "Area",
+          "value": 25.5,
+          "min": -10,
+          "max": 100,
+          "step": 0.5,
+          "fractionsDigits": {min: 1, max: 7}
+        }
       };
 
       dialog.Dialog.form("Please fill in the form", formData )

--- a/source/translation/ru.po
+++ b/source/translation/ru.po
@@ -1,0 +1,87 @@
+#
+msgid ""
+msgstr "Project-Id-Version: 1.0\n"
+"Report-Msgid-Bugs-To: you@your.org\n"
+"POT-Creation-Date: 2011-07-21 20:11+0100\n"
+"PO-Revision-Date: 2011-07-21 20:11+0100\n"
+"Last-Translator: you <you@your.org>\n"
+"Language-Team: Team <yourteam@your.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: dialog.Confirm:117
+msgid "yes"
+msgstr "да"
+
+#: dialog.Confirm:129
+msgid "no"
+msgstr "нет"
+
+#: dialog.Form:436
+msgid "OK"
+msgstr "ОК"
+
+#: dialog.Dialog:443
+msgid "Cancel"
+msgstr "Отмена"
+
+#: dialog.Login:150
+msgid "Name"
+msgstr "Имя"
+
+#: dialog.Login:150
+msgid "Password"
+msgstr "Пароль"
+
+#: dialog.Login:200
+msgid "Login"
+msgstr "Логин"
+
+#: dialog.Wizard:118
+msgid "Back"
+msgstr "Назад"
+
+#: dialog.Wizard:123
+msgid "Next"
+msgstr "Далее"
+
+#: dialog.Wizard:129
+msgid "Finish"
+msgstr "Финиш"
+
+#: qx.util.Validate:90
+msgid "%1 is not a number."
+msgstr "%1 не является числом."
+
+#: qx.util.Validate:129
+msgid "'%1' is not an email address."
+msgstr "'%1' не верный адрес электронной почты."
+
+#: qx.util.Validate:166
+msgid "%1 is not a string."
+msgstr "%1 не является строкой."
+
+#: qx.util.Validate:202
+msgid "%1 is not an url."
+msgstr "%1 не правильный URL."
+
+#: qx.util.Validate:243
+msgid "%1 is not a color! %2"
+msgstr "%1 не является цветом! %2"
+
+#: qx.util.Validate:267
+msgid "%1 is not in the range from [%2, %3]."
+msgstr "%1 не из диапазона [%2, %3]."
+
+#: qx.util.Validate:290
+msgid "%1 is not in %2"
+msgstr "%1 не в %2"
+
+#: qx.util.Validate:314
+msgid "%1 does not fit %2."
+msgstr "%1 не подходит %2."
+
+#: dialog.Login:206
+msgid "Forgot Password?"
+msgstr "Забыли пароль?"


### PR DESCRIPTION
[+] Added support for "qx.ui.form.Spinner" as a field for "dialog.Dialog.form".

Example for use:

```
var formData = {
    name: {
        type: "textfield",
        label: this.tr("Наименование"),
        value: ''
    },
    area: {
        type: "spinner",
        label: this.tr("Площадь"),
        value: 25.5,
        min: -10,
        max: 100,
        step: 0.5,
        fractionsDigits: {min: 1, max: 7}
    }
};

dialog.Dialog.form(this.tr("Добавление"), formData, function (result) {
    if (result !== undefined && result['name'] !== null && result['name'] !== '') {
        alert(result['name'] + ": " + result['area']);
        console.log(result);
    }
});
```
[+] Added translation for the Russian language.