### PR TITLE
Add missing "setLiveUpdate" on password fields.

### DIFF
--- a/source/class/dialog/Form.js
+++ b/source/class/dialog/Form.js
@@ -218,6 +218,7 @@ qx.Class.define("dialog.Form", {
           case "password":
             formElement = new qx.ui.form.PasswordField();
             formElement.getContentElement().setAttribute("autocomplete", "password");
+            formElement.setLiveUpdate(true);
             break;
           case "combobox":
             formElement = new qx.ui.form.ComboBox();


### PR DESCRIPTION
Add missing "setLiveUpdate" on password fields. This causes the model value to be updated on each keypress instead of on blur, and subsequently causes validation to occur.

Note: I have not tested whether other fields could also benefit from this addition.